### PR TITLE
docs: READMEにRepositoriesセクションとOrynthバッジを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,10 @@
 
   [![Status](https://img.shields.io/badge/Status-Beta-yellow)](https://github.com/onizuka-agi-co)
   [![Automation](https://img.shields.io/badge/Automation-Semi--Automatic-orange)](https://github.com/onizuka-agi-co)
+
+  <a href="https://orynth.dev/projects/onizuka-agi-co" target="_blank" rel="noopener">
+    <img src="https://orynth.dev/api/badge/onizuka-agi-co?theme=light&style=minimal" alt="Featured on Orynth" width="152" height="48" />
+  </a>
 </div>
 
 ## 🎯 About
@@ -59,6 +63,17 @@ AIエージェント向けの AgentSkills を開発・公開しています。
 - **daily-memory** - 日報・メモリ管理
 
 詳細は [skills](https://github.com/onizuka-agi-co/skills) リポジトリをご覧ください。
+
+## 📊 Repositories
+
+| リポジトリ | 説明 |
+|-----------|------|
+| [skills](https://github.com/onizuka-agi-co/skills) | OpenClaw Skills for ONIZUKA AGI Co. |
+| [secretary-bot](https://github.com/onizuka-agi-co/secretary-bot) | 🎋 AKARI - YAMLベースのDiscord秘書ボット |
+| [memory](https://github.com/onizuka-agi-co/memory) | 日報・メモリ管理 - VitePress |
+| [workspace](https://github.com/onizuka-agi-co/workspace) | OpenClaw Workspace |
+| [github-app-worker](https://github.com/onizuka-agi-co/github-app-worker) | GitHub App連携ワーカー |
+| [zenn-article](https://github.com/onizuka-agi-co/zenn-article) | Zenn記事の下書き |
 
 ## 📫 Contact
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
   [![Status](https://img.shields.io/badge/Status-Beta-yellow)](https://github.com/onizuka-agi-co)
   [![Automation](https://img.shields.io/badge/Automation-Semi--Automatic-orange)](https://github.com/onizuka-agi-co)
+
+  <a href="https://orynth.dev/projects/onizuka-agi-co" target="_blank" rel="noopener">
+    <img src="https://orynth.dev/api/badge/onizuka-agi-co?theme=light&style=minimal" alt="Featured on Orynth" width="152" height="48" />
+  </a>
 </div>
 
 ## 🎯 About
@@ -59,6 +63,17 @@ We develop and publish AgentSkills for AI agents.
 - **daily-memory** - Daily report and memory management
 
 See the [skills](https://github.com/onizuka-agi-co/skills) repository for details.
+
+## 📊 Repositories
+
+| Repository | Description |
+|------------|-------------|
+| [skills](https://github.com/onizuka-agi-co/skills) | OpenClaw Skills for ONIZUKA AGI Co. |
+| [secretary-bot](https://github.com/onizuka-agi-co/secretary-bot) | 🎋 AKARI - YAML-based Discord Secretary Bot |
+| [memory](https://github.com/onizuka-agi-co/memory) | Daily reports & memory - VitePress powered |
+| [workspace](https://github.com/onizuka-agi-co/workspace) | OpenClaw Workspace |
+| [github-app-worker](https://github.com/onizuka-agi-co/github-app-worker) | GitHub App integration worker |
+| [zenn-article](https://github.com/onizuka-agi-co/zenn-article) | Zenn article drafts |
 
 ## 📫 Contact
 


### PR DESCRIPTION
## 変更内容

- 📊 **Repositoriesセクション**を追加（組織の全リポジトリ一覧）
- 🏆 **Orynthバッジ**をヘッダーに追加
- 英語版・日本語版両方に適用

## 追加されたリポジトリ

| Repository | Description |
|------------|-------------|
| skills | OpenClaw Skills for ONIZUKA AGI Co. |
| secretary-bot | 🎋 AKARI - YAML-based Discord Secretary Bot |
| memory | Daily reports & memory - VitePress powered |
| workspace | OpenClaw Workspace |
| github-app-worker | GitHub App integration worker |
| zenn-article | Zenn article drafts |

## 関連

スレッドでの依頼: #📂-onizuka-agi-co → #README整備